### PR TITLE
Added locked chunks, similar to locked districts. Plus minor CollectTax event QOL.

### DIFF
--- a/common/java/net/fexcraft/mod/landdev/data/chunk/Chunk_.java
+++ b/common/java/net/fexcraft/mod/landdev/data/chunk/Chunk_.java
@@ -46,6 +46,7 @@ public class Chunk_ implements Saveable, Layer, LDUIModule {
 	public ExternalData external = new ExternalData(this);
 	public District district;
 	public long loaded;
+	public boolean locked;
 	public UniChunk uck;
 
 	public Chunk_(UniChunk ck){
@@ -73,6 +74,7 @@ public class Chunk_ implements Saveable, Layer, LDUIModule {
 		label.save(map);
 		if(district != null) map.add("district", district.id);
 		external.save(this, map);
+		if(locked) map.add("locked", true);
 	}
 
 	@Override
@@ -91,6 +93,7 @@ public class Chunk_ implements Saveable, Layer, LDUIModule {
 		district = ResManager.getDistrict(map.getInteger("district", -1));
 		if(district.disbanded) district = ResManager.getDistrict(-1);
 		external.load(this, map);
+		locked = map.getBoolean("locked", false);
 		TaxSystem.taxChunk(this, null, false);
 	}
 	
@@ -128,6 +131,7 @@ public class Chunk_ implements Saveable, Layer, LDUIModule {
 
 	public boolean can_manage(LDPlayer player){
 		if(player.adm) return true;
+		if(locked) return false;
 		UUID uuid = player.uuid;
 		if(owner.playerchunk && owner.player.equals(uuid)) return true;
 		else if(owner.owner.is(Layers.DISTRICT) && district.can(MANAGE_DISTRICT, uuid)) return true;
@@ -155,6 +159,9 @@ public class Chunk_ implements Saveable, Layer, LDUIModule {
 		switch(container.pos.x){
 			case UI_MAIN:
 				boolean canman = can_manage(container.ldp);// || container.ldp.adm;
+				if(locked){
+					resp.addRow("locked", ELM_RED, key.comma());
+				}
 				resp.addRow("key", ELM_GENERIC, key.comma());
 				if(LDConfig.CHUNK_LINK_LIMIT > 0){
 					if(link == null){

--- a/common/java/net/fexcraft/mod/landdev/util/TaxSystem.java
+++ b/common/java/net/fexcraft/mod/landdev/util/TaxSystem.java
@@ -169,6 +169,7 @@ public class TaxSystem extends TimerTask {
 		}
 		broad(Config.getWorthAsString(pytax) + " player tax collected.");
 		broad(Config.getWorthAsString(cktax + pytax) + " tax collected in total.");
+		LDEvent.run(new CollectTaxEvent(null)); // Called without a layer at the end to signify all layers have been taxed
 	}
 
 	public static long taxPlayer(LDPlayer player, Long date, boolean ignore){

--- a/common/resources/assets/landdev/lang/en_us.lang
+++ b/common/resources/assets/landdev/lang/en_us.lang
@@ -277,6 +277,7 @@ landdev.gui.chunk.links.title=List of linked Chunks:
 landdev.gui.chunk.links.submit=Go to selected Chunk Info
 landdev.gui.chunk.linked.title=This Chunk is currently linked to:
 landdev.gui.chunk.linked.disconnect=Disconnect?
+landdev.gui.chunk.locked=Chunk is locked.
 landdev.gui.chunk.select_type.title=Chunk Protection Type
 landdev.gui.chunk.select_type.submit=Confirm Change
 landdev.gui.chunk.select_type.notforplayerchunks=This Type is not available for Player owned chunks.


### PR DESCRIPTION
This is not to be confused with the locked chunk type, this prevents any non admin from changing details about a chunk when enabled. Also had the CollectTax event return no layer once all layers have been taxed for the purpose of custom broadcasts that external fees have been collected and things of that nature.

The chunk's can_manage should respect admin permissions, but if I missed anything please let me know!